### PR TITLE
Update TypeScript declarations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
   - "6"
-  - "5"
   - "4"
   - "0.12"
   - "0.10"

--- a/chai-iterator.d.ts
+++ b/chai-iterator.d.ts
@@ -26,16 +26,20 @@ declare module "chai/lib/Assertion" {
 
   interface Assertion {
     iterable: Assertion;
-    iterate: Assertion;
-    over(values: any[]): Assertion;
-    from(values: any[]): Assertion;
-    until(values: any[]): Assertion;
+    iterate: {
+      over(values: Iterable<any>): Assertion;
+      from(values: Iterable<any>): Assertion;
+      until(values: Iterable<any>): Assertion;
+    };
   }
 
   interface Deep {
-    iterate: Assertion;
+    iterate: {
+      over(values: Iterable<any>): Assertion;
+      from(values: Iterable<any>): Assertion;
+      until(values: Iterable<any>): Assertion;
+    };
   }
-
 }
 
 declare function chaiIterator(chai: any, utils: any): void;

--- a/test/typescript/chai-iterator.ts
+++ b/test/typescript/chai-iterator.ts
@@ -11,14 +11,18 @@ chai.use(chaiIterator);
 // Expect/Should
 
 [2, 3, 5].should.be.iterable;
+"abcdefg".should.be.iterable;
 
 [2, 3, 5].should.iterate.over([2, 3, 5]);
+"abcdefg".should.iterate.over("abcdefg");
 [{id: 2}, {id: 3}].should.deep.iterate.over([{id: 2}, {id: 3}]);
 
 [2, 3, 5].should.iterate.from([2, 3]);
+"abcdefg".should.iterate.from("abc");
 [{id: 2}, {id: 3}].should.deep.iterate.from([{id: 2}]);
 
 [2, 3, 5].should.iterate.until([3, 5]);
+"abcdefg".should.iterate.until("efg");
 [{id: 2}, {id: 3}].should.deep.iterate.until([{id: 3}]);
 
 // Assert


### PR DESCRIPTION
#### Fixes

- In TypeScript declarations, `over()`, `from()`, and `until()` methods are now only properties of `iterate`, since they must follow `iterate` for the assertion to pass

#### Development

- New tests for TypeScript declarations, using strings as iterables
- Node 5 removed from Travis build