### PR TITLE
Fix: TypeScript declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,11 +200,11 @@ function will also be available globally as `chaiIterator`.
 #### TypeScript
 
 [TypeScript][typescript] declarations are included in the package. To use them,
-first ensure the [npm declarations for Chai][chai-typings] are installed via
-[typings][typings].
+ensure Chai Iterator is installed with [npm][npm], then install the declarations
+and their dependencies via [typings][typings].
 
 ```sh
-typings install npm~chai --save
+typings install --save-dev npm:chai-iterator
 ```
 
 In the [compiler options][compiler-options], set `"target"` to `"es6"`, or at

--- a/chai-iterator.d.ts
+++ b/chai-iterator.d.ts
@@ -1,4 +1,6 @@
-declare module "chai/lib/Assert" {
+import "chai";
+
+declare module "~chai/lib/Assert" {
 
   interface Assert {
     isIterable(val: any, msg?: string): void;
@@ -22,7 +24,7 @@ declare module "chai/lib/Assert" {
 
 }
 
-declare module "chai/lib/Assertion" {
+declare module "~chai/lib/Assertion" {
 
   interface Assertion {
     iterable: Assertion;


### PR DESCRIPTION
TypeScript declarations are now installable like so:

```js
typings install --save-dev npm:chai-iterator
```

- The "chai" module is now imported at the top of the declarations file
- The README has been updated accordingly