### PR TITLE
Fix: non-iterable iterators

### DIFF
--- a/chai-iterator.js
+++ b/chai-iterator.js
@@ -44,7 +44,7 @@
   }));
 
   Assertion.addMethod('from', iterateMethod('to begin iteration with', function(exp) {
-    return slice(this._obj, exp.length);
+    return slice(this._obj[Symbol.iterator](), exp.length);
   }));
 
   Assertion.addMethod('until', iterateMethod('to end iteration with', function(exp) {
@@ -259,7 +259,7 @@
       assert(utils.flag(this, 'iterate'), 'the iterate flag must be set');
       new Assertion(iterable).iterable;
 
-      var exp = slice(iterable);
+      var exp = slice(iterable[Symbol.iterator]());
       var act = getActual.call(this, exp);
 
       var deep = utils.flag(this, 'deep') ? ' deep' : '';
@@ -305,12 +305,11 @@
     });
   }
 
-  function slice(iterable, stop) {
+  function slice(it, stop) {
     stop = stop == null ? Infinity : stop;
 
     var result = [];
     var max = stop - 1;
-    var it = iterable[Symbol.iterator]();
     var step = it.next();
 
     for (var i = 0; i <= max && !step.done; i++) {

--- a/test/assert/iterate-from.coffee
+++ b/test/assert/iterate-from.coffee
@@ -1,4 +1,5 @@
 {assert} = require 'chai'
+customIterableFactory = require '../fixtures/custom'
 err = require '../helpers/err'
 
 describe 'assert: iteratesFrom(value, expected, [message])', ->
@@ -82,3 +83,10 @@ describe 'assert: doesNotDeepIterateFrom(value, expected, [message])', ->
 
     it 'throws', ->
       err -> assert.doesNotDeepIterateFrom([{id: 1}, {id: 2}], [{id: 1}])
+
+  context 'iterator returned by @@iterator is not itself iterable', ->
+
+    it 'works correctly', ->
+      iterable = customIterableFactory();
+      err -> assert.iteratesFrom(iterable, [2, 3]);
+      assert.iteratesFrom(iterable, [0, 1]);

--- a/test/assert/iterate-over.coffee
+++ b/test/assert/iterate-over.coffee
@@ -1,4 +1,5 @@
 {assert} = require 'chai'
+customIterableFactory = require '../fixtures/custom'
 err = require '../helpers/err'
 
 describe 'assert: iteratesOver(value, expected, [message])', ->
@@ -89,3 +90,10 @@ describe 'assert: doesNotDeepIterateOver(value, expected, [message])', ->
 
     it 'throws', ->
       err -> assert.doesNotDeepIterateOver([{id: 1}, {id: 2}], [{id: 1}, {id: 2}])
+
+  context 'iterator returned by @@iterator is not itself iterable', ->
+
+    it 'works correctly', ->
+      iterable = customIterableFactory();
+      err -> assert.iteratesOver(iterable, [2, 3, 5]);
+      assert.iteratesOver(iterable, [0, 1, 2]);

--- a/test/assert/iterate-until.coffee
+++ b/test/assert/iterate-until.coffee
@@ -1,4 +1,5 @@
 {assert} = require 'chai'
+customIterableFactory = require '../fixtures/custom'
 err = require '../helpers/err'
 
 describe 'assert: iteratesUntil(value, expected, [message])', ->
@@ -82,3 +83,10 @@ describe 'assert: doesNotDeepIterateUntil(value, expected, [message])', ->
 
     it 'throws', ->
       err -> assert.doesNotDeepIterateUntil([{id: 1}, {id: 2}], [{id: 2}])
+
+  context 'iterator returned by @@iterator is not itself iterable', ->
+
+    it 'works correctly', ->
+      iterable = customIterableFactory();
+      err -> assert.iteratesUntil(iterable, [3, 5]);
+      assert.iteratesUntil(iterable, [1, 2]);

--- a/test/expect-should/iterate-from.coffee
+++ b/test/expect-should/iterate-from.coffee
@@ -1,4 +1,5 @@
 err = require '../helpers/err'
+customIterableFactory = require '../fixtures/custom'
 
 describe 'expect/should: iterate.from(iterable)', ->
 
@@ -35,3 +36,10 @@ describe 'expect/should: iterate.from(iterable)', ->
     it 'throws whether negated or not', ->
       err -> [2, 3, 5].should.from [2, 3]
       err -> [2, 3, 5].should.not.from [3, 5]
+
+context 'iterator returned by @@iterator is not itself iterable', ->
+
+  it 'works correctly', ->
+    iterable = customIterableFactory();
+    err -> iterable.should.iterate.from [2, 3]
+    iterable.should.iterate.from [0, 1]

--- a/test/expect-should/iterate-over.coffee
+++ b/test/expect-should/iterate-over.coffee
@@ -1,4 +1,5 @@
 err = require '../helpers/err'
+customIterableFactory = require '../fixtures/custom'
 
 describe 'expect/should: iterate.over(iterable)', ->
 
@@ -37,3 +38,10 @@ describe 'expect/should: iterate.over(iterable)', ->
     it 'throws whether negated or not', ->
       err -> [2, 3, 5].should.over [2, 3, 5]
       err -> [2, 3, 5].should.not.over [2, 3, 6]
+
+  context 'iterator returned by @@iterator is not itself iterable', ->
+
+    it 'works correctly', ->
+      iterable = customIterableFactory();
+      err -> iterable.should.iterate.over [2, 3, 5]
+      iterable.should.iterate.over [0, 1, 2]

--- a/test/expect-should/iterate-until.coffee
+++ b/test/expect-should/iterate-until.coffee
@@ -1,4 +1,5 @@
 err = require '../helpers/err'
+customIterableFactory = require '../fixtures/custom'
 
 describe 'expect/should: iterate.until(iterable)', ->
 
@@ -35,3 +36,10 @@ describe 'expect/should: iterate.until(iterable)', ->
     it 'throws whether negated or not', ->
       err -> [2, 3, 5].should.until [3, 5]
       err -> [2, 3, 5].should.not.until [2, 3]
+
+  context 'iterator returned by @@iterator is not itself iterable', ->
+
+    it 'works correctly', ->
+      iterable = customIterableFactory();
+      err -> iterable.should.iterate.until [3, 5]
+      iterable.should.iterate.until [1, 2]


### PR DESCRIPTION
Fixes #9

Tests previously assumed that the iterator object returned by @@iterator
would itself be iterable. While this is true of native ES2015 iterators,
it is inconsistent with the iterator protocol. This PR fixes that.